### PR TITLE
Component entity filtering

### DIFF
--- a/rotriever.lock
+++ b/rotriever.lock
@@ -6,3 +6,10 @@ type = "git"
 source = "https://github.com/Roblox/testez"
 commit = "d488b21df0388f8729feda26965123c63de3869f"
 rev = "master"
+
+[[package]]
+name = "t"
+type = "git"
+source = "https://github.com/osyrisrblx/t"
+commit = "07dbb2f2e9fb9a743899d2a3454b262e75cc825e"
+rev = "master"

--- a/rotriever.toml
+++ b/rotriever.toml
@@ -6,3 +6,4 @@ version = "1.0.0"
 
 [dependencies]
 TestEZ = { git = "https://github.com/Roblox/testez", rev = "master" }
+t = { git = "https://github.com/osyrisrblx/t", rev = "master" }

--- a/src/Core.spec/addComponent.spec.lua
+++ b/src/Core.spec/addComponent.spec.lua
@@ -2,9 +2,12 @@ local Core = require(script.Parent.Parent.Core)
 local defineComponent = require(script.Parent.Parent.defineComponent)
 
 return function()
-    local ComponentClass = defineComponent("TestComponent", function()
-        return {}
-    end)
+    local ComponentClass = defineComponent({
+        name = "TestComponent",
+        generator = function()
+            return {}
+        end
+    })
 
     it("should add components", function()
         local core = Core.new()

--- a/src/Core.spec/addComponent.spec.lua
+++ b/src/Core.spec/addComponent.spec.lua
@@ -46,4 +46,26 @@ return function()
             core:addComponent(entity, ComponentClass)
         end).to.throw()
     end)
+
+    it("should throw if the component's entityFilter forbids the addition", function()
+        local core = Core.new()
+        local entity = core:createEntity()
+
+        local FilteredComponent = defineComponent({
+            name = "Filtered",
+            generator = function()
+                return {}
+            end,
+            entityFilter = function(testEntity)
+                expect(testEntity).to.equal(entity)
+                return false
+            end,
+        })
+
+        core:registerComponent(FilteredComponent)
+
+        expect(function()
+            core:addComponent(entity, FilteredComponent)
+        end).to.throw()
+    end)
 end

--- a/src/Core.spec/batchAddComponents.spec.lua
+++ b/src/Core.spec/batchAddComponents.spec.lua
@@ -103,4 +103,26 @@ return function()
             core:batchAddComponents(entity, ComponentA, ComponentB, ComponentC)
         end).to.throw()
     end)
+
+    it("should throw if a component's entityFilter forbids the addition", function()
+        local core = Core.new()
+        local entity = core:createEntity()
+
+        local FilteredComponent = defineComponent({
+            name = "Filtered",
+            generator = function()
+                return {}
+            end,
+            entityFilter = function(testEntity)
+                expect(testEntity).to.equal(entity)
+                return false
+            end,
+        })
+
+        core:registerComponent(FilteredComponent)
+
+        expect(function()
+            core:batchAddComponents(entity, FilteredComponent)
+        end).to.throw()
+    end)
 end

--- a/src/Core.spec/batchAddComponents.spec.lua
+++ b/src/Core.spec/batchAddComponents.spec.lua
@@ -2,17 +2,26 @@ local Core = require(script.Parent.Parent.Core)
 local defineComponent = require(script.Parent.Parent.defineComponent)
 
 return function()
-    local ComponentA = defineComponent("A", function()
-        return {}
-    end)
+    local ComponentA = defineComponent({
+        name = "A",
+        generator = function()
+            return {}
+        end,
+    })
 
-    local ComponentB = defineComponent("B", function()
-        return {}
-    end)
+    local ComponentB = defineComponent({
+        name = "B",
+        generator = function()
+            return {}
+        end,
+    })
 
-    local ComponentC = defineComponent("C", function()
-        return {}
-    end)
+    local ComponentC = defineComponent({
+        name = "C",
+        generator = function()
+            return {}
+        end,
+    })
 
     it("should add components", function()
         local core = Core.new()

--- a/src/Core.spec/batchRemoveComponents.spec.lua
+++ b/src/Core.spec/batchRemoveComponents.spec.lua
@@ -2,17 +2,26 @@ local Core = require(script.Parent.Parent.Core)
 local defineComponent = require(script.Parent.Parent.defineComponent)
 
 return function()
-    local ComponentA = defineComponent("A", function()
-        return {}
-    end)
+    local ComponentA = defineComponent({
+        name = "A",
+        generator = function()
+            return {}
+        end,
+    })
 
-    local ComponentB = defineComponent("B", function()
-        return {}
-    end)
+    local ComponentB = defineComponent({
+        name = "B",
+        generator = function()
+            return {}
+        end,
+    })
 
-    local ComponentC = defineComponent("C", function()
-        return {}
-    end)
+    local ComponentC = defineComponent({
+        name = "C",
+        generator = function()
+            return {}
+        end,
+    })
 
     it("should remove components", function()
         local core = Core.new()

--- a/src/Core.spec/components.spec.lua
+++ b/src/Core.spec/components.spec.lua
@@ -3,9 +3,12 @@ local defineComponent = require(script.Parent.Parent.defineComponent)
 
 return function()
     it("should iterate over entities", function()
-        local ComponentClass = defineComponent("TestComponent", function()
-            return {}
-        end)
+        local ComponentClass = defineComponent({
+            name = "TestComponent",
+            generator = function()
+                return {}
+            end
+        })
 
         local core = Core.new()
         core:registerComponent(ComponentClass)
@@ -21,13 +24,19 @@ return function()
     end)
 
     it("should return components in the order specified", function()
-        local ComponentA = defineComponent("A", function()
-            return {}
-        end)
+        local ComponentA = defineComponent({
+            name = "A",
+            generator = function()
+                return {}
+            end,
+        })
 
-        local ComponentB = defineComponent("B", function()
-            return {}
-        end)
+        local ComponentB = defineComponent({
+            name = "B",
+            generator = function()
+                return {}
+            end,
+        })
 
         local core = Core.new()
         core:registerComponent(ComponentA)
@@ -52,13 +61,19 @@ return function()
     end)
 
     it("should exclude entities that do not have all the components", function()
-        local ComponentA = defineComponent("A", function()
-            return {}
-        end)
+        local ComponentA = defineComponent({
+            name = "A",
+            generator = function()
+                return {}
+            end,
+        })
 
-        local ComponentB = defineComponent("B", function()
-            return {}
-        end)
+        local ComponentB = defineComponent({
+            name = "B",
+            generator = function()
+                return {}
+            end,
+        })
 
         local core = Core.new()
         core:registerComponent(ComponentA)
@@ -82,13 +97,19 @@ return function()
     end)
 
     it("should include entities that have components that are not specified", function()
-        local ComponentA = defineComponent("A", function()
-            return {}
-        end)
+        local ComponentA = defineComponent({
+            name = "A",
+            generator = function()
+                return {}
+            end,
+        })
 
-        local ComponentB = defineComponent("B", function()
-            return {}
-        end)
+        local ComponentB = defineComponent({
+            name = "B",
+            generator = function()
+                return {}
+            end,
+        })
 
         local core = Core.new()
         core:registerComponent(ComponentA)

--- a/src/Core.spec/getComponent.spec.lua
+++ b/src/Core.spec/getComponent.spec.lua
@@ -2,9 +2,12 @@ local Core = require(script.Parent.Parent.Core)
 local defineComponent = require(script.Parent.Parent.defineComponent)
 
 return function()
-    local ComponentClass = defineComponent("TestComponent", function()
-        return {}
-    end)
+    local ComponentClass = defineComponent({
+        name = "TestComponent",
+        generator = function()
+            return {}
+        end
+    })
 
     it("should get components", function()
         local core = Core.new()

--- a/src/Core.spec/getComponentAddedSignal.spec.lua
+++ b/src/Core.spec/getComponentAddedSignal.spec.lua
@@ -2,9 +2,12 @@ local Core = require(script.Parent.Parent.Core)
 local defineComponent = require(script.Parent.Parent.defineComponent)
 
 return function()
-    local ComponentClass = defineComponent("TestComponent", function()
-        return {}
-    end)
+    local ComponentClass = defineComponent({
+        name = "TestComponent",
+        generator = function()
+            return {}
+        end
+    })
 
     it("should get a signal", function()
         local core = Core.new()

--- a/src/Core.spec/getComponentRemovingSignal.spec.lua
+++ b/src/Core.spec/getComponentRemovingSignal.spec.lua
@@ -2,9 +2,12 @@ local Core = require(script.Parent.Parent.Core)
 local defineComponent = require(script.Parent.Parent.defineComponent)
 
 return function()
-    local ComponentClass = defineComponent("TestComponent", function()
-        return {}
-    end)
+    local ComponentClass = defineComponent({
+        name = "TestComponent",
+        generator = function()
+            return {}
+        end
+    })
 
     it("should get a signal", function()
         local core = Core.new()

--- a/src/Core.spec/init.lua
+++ b/src/Core.spec/init.lua
@@ -30,66 +30,75 @@ return function()
     end)
 
     describe("registerComponent", function()
-        local component = defineComponent("TestComponent", function()
-            return {}
-        end)
+        local ComponentClass = defineComponent({
+            name = "TestComponent",
+            generator = function()
+                return {}
+            end
+        })
 
         it("should succeed when called", function()
             local core = Core.new()
-            core:registerComponent(component)
+            core:registerComponent(ComponentClass)
         end)
 
         it("should throw when registering a component repeatedly", function()
             local core = Core.new()
-            core:registerComponent(component)
+            core:registerComponent(ComponentClass)
 
             expect(function()
-                core:registerComponent(component)
+                core:registerComponent(ComponentClass)
             end).to.throw()
         end)
     end)
 
     describe("addSingleton", function()
-        local component = defineComponent("TestSingleton", function()
-            return {}
-        end)
+        local SingletonClass = defineComponent({
+            name = "TestSingleton",
+            generator = function()
+                return {}
+            end
+        })
 
         it("should add singleton components", function()
             local core = Core.new()
-            local singleton = core:addSingleton(component)
+            local singleton = core:addSingleton(SingletonClass)
             expect(singleton).to.be.ok()
-            expect(core:getSingleton(component)).to.be.ok()
-            expect(core:getSingleton(component)).to.equal(singleton)
+            expect(core:getSingleton(SingletonClass)).to.be.ok()
+            expect(core:getSingleton(SingletonClass)).to.equal(singleton)
         end)
 
         it("should throw if the singleton is already added", function()
             local core = Core.new()
-            core:addSingleton(component)
+            core:addSingleton(SingletonClass)
 
             expect(function()
-                core:addSingleton(component)
+                core:addSingleton(SingletonClass)
             end).to.throw()
         end)
     end)
 
     describe("getSingleton", function()
-        local component = defineComponent("TestSingleton", function()
-            return {}
-        end)
+        local SingletonClass = defineComponent({
+            name = "TestSingleton",
+            generator = function()
+                return {}
+            end
+        })
 
         it("should get singleton components", function()
             local core = Core.new()
-            local singleton = core:addSingleton(component)
+            local singleton = core:addSingleton(SingletonClass)
             expect(singleton).to.be.ok()
-            expect(core:getSingleton(component)).to.be.ok()
-            expect(core:getSingleton(component)).to.equal(singleton)
+            expect(core:getSingleton(SingletonClass)).to.be.ok()
+            expect(core:getSingleton(SingletonClass)).to.equal(singleton)
         end)
 
         it("should throw if the singleton isn't added", function()
             local core = Core.new()
 
             expect(function()
-                core:getSingleton(component)
+                core:getSingleton(SingletonClass)
             end).to.throw()
         end)
     end)

--- a/src/Core.spec/plugins.spec.lua
+++ b/src/Core.spec/plugins.spec.lua
@@ -80,9 +80,12 @@ return function()
 
     describe("componentRegistered", function()
         it("should be called when a component is registered", function()
-            local ComponentClass = defineComponent("TestComponent", function()
-                return {}
-            end)
+            local ComponentClass = defineComponent({
+                name = "TestComponent",
+                generator = function()
+                    return {}
+                end
+            })
 
             local callCount = 0
 
@@ -101,9 +104,12 @@ return function()
 
     describe("componentAdded", function()
         it("should be called when a component is added to an entity", function()
-            local ComponentClass = defineComponent("TestComponent", function()
-                return {}
-            end)
+            local ComponentClass = defineComponent({
+                name = "TestComponent",
+                generator = function()
+                    return {}
+                end
+            })
 
             local callCount = 0
             local calledEntity = nil
@@ -130,9 +136,12 @@ return function()
         end)
 
         it("should be called before events are fired in addComponent", function()
-            local ComponentClass = defineComponent("TestComponent", function()
-                return {}
-            end)
+            local ComponentClass = defineComponent({
+                name = "TestComponent",
+                generator = function()
+                    return {}
+                end
+            })
 
             local eventFired = false
 
@@ -155,9 +164,12 @@ return function()
         end)
 
         it("should be called before events are fired in batchAddComponents", function()
-            local ComponentClass = defineComponent("TestComponent", function()
-                return {}
-            end)
+            local ComponentClass = defineComponent({
+                name = "TestComponent",
+                generator = function()
+                    return {}
+                end
+            })
 
             local eventFired = false
 
@@ -182,9 +194,12 @@ return function()
 
     describe("componentRemoving", function()
         it("should be called when a component is removed from an entity", function()
-            local ComponentClass = defineComponent("TestComponent", function()
-                return {}
-            end)
+            local ComponentClass = defineComponent({
+                name = "TestComponent",
+                generator = function()
+                    return {}
+                end
+            })
 
             local callCount = 0
             local calledEntity = nil
@@ -212,9 +227,12 @@ return function()
         end)
 
         it("should be called when an entity is destroyed", function()
-            local ComponentClass = defineComponent("TestComponent", function()
-                return {}
-            end)
+            local ComponentClass = defineComponent({
+                name = "TestComponent",
+                generator = function()
+                    return {}
+                end
+            })
 
             local callCount = 0
             local calledEntity = nil
@@ -242,9 +260,12 @@ return function()
         end)
 
         it("should be called after events are fired in removeComponent", function()
-            local ComponentClass = defineComponent("TestComponent", function()
-                return {}
-            end)
+            local ComponentClass = defineComponent({
+                name = "TestComponent",
+                generator = function()
+                    return {}
+                end
+            })
 
             local eventFired = false
 
@@ -268,9 +289,12 @@ return function()
         end)
 
         it("should be called after events are fired in batchRemoveComponents", function()
-            local ComponentClass = defineComponent("TestComponent", function()
-                return {}
-            end)
+            local ComponentClass = defineComponent({
+                name = "TestComponent",
+                generator = function()
+                    return {}
+                end
+            })
 
             local eventFired = false
 
@@ -294,9 +318,12 @@ return function()
         end)
 
         it("should be called after events are fired in destroyEntity", function()
-            local ComponentClass = defineComponent("TestComponent", function()
-                return {}
-            end)
+            local ComponentClass = defineComponent({
+                name = "TestComponent",
+                generator = function()
+                    return {}
+                end
+            })
 
             local eventFired = false
 
@@ -322,9 +349,12 @@ return function()
 
     describe("singletonAdded", function()
         it("should be called when a singleton is added", function()
-            local ComponentClass = defineComponent("TestComponent", function()
-                return {}
-            end)
+            local ComponentClass = defineComponent({
+                name = "TestComponent",
+                generator = function()
+                    return {}
+                end
+            })
 
             local callCount = 0
             local calledSingleton = nil

--- a/src/Core.spec/removeComponent.spec.lua
+++ b/src/Core.spec/removeComponent.spec.lua
@@ -2,9 +2,12 @@ local Core = require(script.Parent.Parent.Core)
 local defineComponent = require(script.Parent.Parent.defineComponent)
 
 return function()
-    local ComponentClass = defineComponent("TestComponent", function()
-        return {}
-    end)
+    local ComponentClass = defineComponent({
+        name = "TestComponent",
+        generator = function()
+            return {}
+        end
+    })
 
     it("should remove components", function()
         local core = Core.new()

--- a/src/defineComponent.lua
+++ b/src/defineComponent.lua
@@ -6,6 +6,7 @@
     The argument table should have the following keys:
     - name (string)
     - generator (() -> table)
+    - entityFilter (entity -> bool)
 
     The name must be a string; there are no restrictions on its value otherwise.
     However, duplicate names are not recommended, as Cores require that all
@@ -16,6 +17,14 @@
     provide the className field that will refer to the class name of the
     component.
 
+    The entity filter function must take an entity and return a boolean
+    indicating whether the component can be applied to that entity. This can be
+    used to ensure that a component is only attached to entities that are Roblox
+    instances, or specific Roblox instances, or only abstract entities.
+
+    If the entity filter function is not present in the args table, the
+    component can be attached to any entity.
+
 ]]
 
 local t = require(script.Parent.Parent.t)
@@ -23,6 +32,7 @@ local t = require(script.Parent.Parent.t)
 local isComponentArgs = t.strictInterface({
     name = t.string,
     generator = t.callback,
+    entityFilter = t.optional(t.callback),
 })
 
 local errorFormats = {
@@ -35,6 +45,7 @@ local function defineComponent(args)
 
     local definition = {}
     definition.className = args.name
+    definition.entityFilter = args.entityFilter
     definition.__index = definition
 
     local generator = args.generator

--- a/src/defineComponent.lua
+++ b/src/defineComponent.lua
@@ -1,43 +1,49 @@
 --[[
 
-    defineComponent is a utility function for defining a component. Given a name
-    and a function that returns a table, it creates a component class that can
-    be registered with a Core.
+    defineComponent is a utility function for defining a component. Given an
+    argument table, it creates a component class.
+
+    The argument table should have the following keys:
+    - name (string)
+    - generator (() -> table)
 
     The name must be a string; there are no restrictions on its value otherwise.
     However, duplicate names are not recommended, as Cores require that all
     components registered in them have unique names.
 
-    The creator function must return a table. The exact contents of the table
-    are up to the user; RECS imposes no restrictions on it.
+    The generator function must return a table. The exact contents of the table
+    are up to the user; RECS imposes no restrictions on it. However, RECS does
+    provide the className field that will refer to the class name of the
+    component.
 
 ]]
 
+local t = require(script.Parent.Parent.t)
+
+local isComponentArgs = t.strictInterface({
+    name = t.string,
+    generator = t.callback,
+})
+
 local errorFormats = {
-    nonStringName = "name (1) must be a string, is a %s",
-    nonFunctionDefaultProps = "defaultPropsGenerator (2) must be a function, is a %s",
     nonTableDefaultPropsReturn =
         "The defaultProps generator for the %s component must return a table, but it returned a %s",
 }
 
-local function defineComponent(name, defaultPropsGenerator)
-    assert(
-        typeof(name) == "string",
-        errorFormats.nonStringName:format(typeof(name)))
-
-    assert(
-        typeof(defaultPropsGenerator) == "function",
-        errorFormats.nonFunctionDefaultProps:format(typeof(defaultPropsGenerator)))
+local function defineComponent(args)
+    assert(isComponentArgs(args))
 
     local definition = {}
-    definition.className = name
+    definition.className = args.name
     definition.__index = definition
 
+    local generator = args.generator
+
     function definition._create()
-        local component = defaultPropsGenerator()
+        local component = generator()
 
         if typeof(component) ~= "table" then
-            error(errorFormats.nonTableDefaultPropsReturn:format(name, typeof(component)))
+            error(errorFormats.nonTableDefaultPropsReturn:format(args.name, typeof(component)))
         end
 
         setmetatable(component, definition)

--- a/src/defineComponent.spec.lua
+++ b/src/defineComponent.spec.lua
@@ -2,38 +2,58 @@ local defineComponent = require(script.Parent.defineComponent)
 
 return function()
     it("should create component classes", function()
-        expect(defineComponent("test", function() end)).to.be.ok()
+        expect(defineComponent({
+            name = "Test",
+            generator = function() end,
+        })).to.be.ok()
     end)
 
     it("should create component classes with a name and creator", function()
-        local component = defineComponent("Test", function() end)
-        expect(typeof(component.className)).to.equal("string")
-        expect(component.className).to.equal("Test")
+        local component = defineComponent({
+            name = "Test",
+            generator = function() end
+        })
 
+        expect(component.className).to.equal("Test")
         expect(typeof(component._create)).to.equal("function")
+    end)
+
+    it("should throw if args is not a table", function()
+        expect(function()
+            defineComponent("Test", function() end)
+        end).to.throw()
     end)
 
     it("should throw if given a non-string name", function()
         expect(function()
-            defineComponent(123, function()
-            end)
+            defineComponent({
+                name = 123,
+                generator = function()
+                end,
+            })
         end).to.throw()
     end)
 
     it("should throw if given a non-function generator", function()
         expect(function()
-            defineComponent("test", true)
+            defineComponent({
+                name = "Test",
+                generator = true,
+            })
         end).to.throw()
     end)
 
     describe("_create", function()
         it("should create components", function()
-            local class = defineComponent("test", function()
-                return {
-                    a = 1,
-                    b = 2,
-                }
-            end)
+            local class = defineComponent({
+                name = "Test",
+                generator = function()
+                    return {
+                        a = 1,
+                        b = 2,
+                    }
+                end,
+            })
 
             local component = class._create()
             expect(component.a).to.equal(1)
@@ -41,20 +61,26 @@ return function()
         end)
 
         it("should throw if the generator function does not return a table", function()
-            local class = defineComponent("test", function()
-                return 123456
-            end)
+            local class = defineComponent({
+                name = "Test",
+                generator = function()
+                    return 123
+                end,
+            })
 
             expect(class._create).to.throw()
         end)
 
         it("should set up the metatable properly", function()
-            local class = defineComponent("test", function()
-                return {
-                    a = 1,
-                    b = 2,
-                }
-            end)
+            local class = defineComponent({
+                name = "Test",
+                generator = function()
+                    return {
+                        a = 1,
+                        b = 2,
+                    }
+                end,
+            })
 
             function class:setA(newA)
                 self.a = newA

--- a/src/defineComponent.spec.lua
+++ b/src/defineComponent.spec.lua
@@ -43,6 +43,24 @@ return function()
         end).to.throw()
     end)
 
+    it("should accept an entity filter", function()
+        defineComponent({
+            name = "Test",
+            generator = function() end,
+            entityFilter = function() end,
+        })
+    end)
+
+    it("should throw if given a non-function entity filter", function()
+        expect(function()
+            defineComponent({
+                name = "Test",
+                generator = function() end,
+                entityFilter = true,
+            })
+        end).to.throw()
+    end)
+
     describe("_create", function()
         it("should create components", function()
             local class = defineComponent({


### PR DESCRIPTION
Closes #23.

Changes the signature of `defineComponent` to take a dictionary of arguments instead of a tuple. Also switches to using `t` to validate this. In the future, `t` will be used in more places. The first argument, the component class name, is specified with the `name` field; the generator function is specified with the `generator` field. Both are mandatory.

Using the new dictionary table, there is a new optional argument, `entityFilter`. It takes an entity (whether abstract entity ID or Roblox instance) and should return a bool. If it returns `false` for a given entity, `addComponent` and `batchAddComponents` will throw when trying to add the component to that entity. Otherwise, the addition proceeds as normal. `batchAddComponents` throws if any component cannot be added to the entity.