### PR TITLE
Fixed: ComponentChangedEvent plugin event firing in cases where the value didn't change

### DIFF
--- a/src/BuiltInPlugins/ComponentChangedEvent.lua
+++ b/src/BuiltInPlugins/ComponentChangedEvent.lua
@@ -6,6 +6,10 @@ function componentChangedEventPlugin:componentRegistered(core, componentClass)
     function componentClass.updateProperty(componentInstance, key, newValue)
         local oldValue = componentInstance[key]
 
+        if oldValue == newValue then
+            return
+        end
+
         componentInstance[key] = newValue
 
         componentInstance.raisePropertyChanged(key, newValue, oldValue)


### PR DESCRIPTION
Property changed event no longer fires if the new value is the same as the old value