### PR TITLE
optional props argument to core:addComponent()

### DIFF
--- a/src/Core.lua
+++ b/src/Core.lua
@@ -334,6 +334,7 @@ function Core:addComponent(entityId, componentIdentifier, props)
             componentInstance = componentClass._create()
             componentInstances[entityId] = componentInstance
 
+            -- apply props to new component
             if props then
                 for k,v in pairs(props) do
                     componentInstance[k] =  v

--- a/src/Core.lua
+++ b/src/Core.lua
@@ -317,7 +317,7 @@ end
     Throws if the identified component class isn't registered in the Core.
 
 ]]
-function Core:addComponent(entityId, componentIdentifier)
+function Core:addComponent(entityId, componentIdentifier, props)
     componentIdentifier = resolveComponentByIdentifier(componentIdentifier)
     local componentClass = self._componentClasses[componentIdentifier]
 
@@ -333,6 +333,12 @@ function Core:addComponent(entityId, componentIdentifier)
         else
             componentInstance = componentClass._create()
             componentInstances[entityId] = componentInstance
+
+            if props then
+                for k,v in pairs(props) do
+                    componentInstance[k] =  v
+                end
+            end
 
             self:__callPluginMethod("componentAdded", entityId, componentInstance)
 


### PR DESCRIPTION
The purpose of this argument is to allow users to pass props to a component as it is added to an entity. These props would be set before the component added signal is fired and as such can be reasoned with in connections to that signal. The current method of adding a component, getting said component, and then changing properties, can be quite clunky, especially if you are listening to the addition of a component to an entity in a system.

Another solution could be allowing users to create a component, set properties, then attach said component to the entity.