### PR TITLE
Props argument for Core:addComponent()

### DIFF
--- a/src/Core.lua
+++ b/src/Core.lua
@@ -317,7 +317,7 @@ end
     Throws if the identified component class isn't registered in the Core.
 
 ]]
-function Core:addComponent(entityId, componentIdentifier)
+function Core:addComponent(entityId, componentIdentifier, props)
     componentIdentifier = resolveComponentByIdentifier(componentIdentifier)
     local componentClass = self._componentClasses[componentIdentifier]
 
@@ -331,7 +331,7 @@ function Core:addComponent(entityId, componentIdentifier)
             -- Don't re-create the component or overwrite what's already there!
             return false, componentInstance
         else
-            componentInstance = componentClass._create()
+            componentInstance = componentClass._create(props)
             componentInstances[entityId] = componentInstance
 
             self:__callPluginMethod("componentAdded", entityId, componentInstance)

--- a/src/Core.spec/addComponent.spec.lua
+++ b/src/Core.spec/addComponent.spec.lua
@@ -7,6 +7,7 @@ return function()
         generator = function(props)
             props = props or {
                 a = 0
+
             }
             return {
                 a = props.a + 1

--- a/src/Core.spec/addComponent.spec.lua
+++ b/src/Core.spec/addComponent.spec.lua
@@ -38,7 +38,7 @@ return function()
         core:registerComponent(ComponentClass)
 
         local entity = core:createEntity()
-        local addedNew, component = core:addComponent(entity, ComponentClass, {
+        local _, component = core:addComponent(entity, ComponentClass, {
             a = 1
         })
 

--- a/src/Core.spec/addComponent.spec.lua
+++ b/src/Core.spec/addComponent.spec.lua
@@ -39,7 +39,7 @@ return function()
 
         local entity = core:createEntity()
         local _, component = core:addComponent(entity, ComponentClass, {
-            a = 1
+            a = 1,
         })
 
         expect(component.a).to.equal(2)

--- a/src/Core.spec/addComponent.spec.lua
+++ b/src/Core.spec/addComponent.spec.lua
@@ -10,7 +10,7 @@ return function()
 
             }
             return {
-                a = props.a + 1
+                a = props.a + 1,
             }
         end
     })

--- a/src/Core.spec/addComponent.spec.lua
+++ b/src/Core.spec/addComponent.spec.lua
@@ -6,7 +6,7 @@ return function()
         name = "TestComponent",
         generator = function(props)
             props = props or {
-                a = 0
+                a = 0,
 
             }
             return {

--- a/src/Core.spec/addComponent.spec.lua
+++ b/src/Core.spec/addComponent.spec.lua
@@ -4,8 +4,13 @@ local defineComponent = require(script.Parent.Parent.defineComponent)
 return function()
     local ComponentClass = defineComponent({
         name = "TestComponent",
-        generator = function()
-            return {}
+        generator = function(props)
+            props = props or {
+                a = 0
+            }
+            return {
+                a = props.a + 1
+            }
         end
     })
 
@@ -25,6 +30,18 @@ return function()
         local addedNew, component = core:addComponent(entity, ComponentClass)
         expect(addedNew).to.equal(true)
         expect(component).to.be.ok()
+    end)
+
+    it("should add components with props", function()
+        local core = Core.new()
+        core:registerComponent(ComponentClass)
+
+        local entity = core:createEntity()
+        local addedNew, component = core:addComponent(entity, ComponentClass, {
+            a = 1
+        })
+
+        expect(component.a).to.equal(2)
     end)
 
     it("should return false plus the existing component if the component already exists", function()

--- a/src/defineComponent.lua
+++ b/src/defineComponent.lua
@@ -50,8 +50,8 @@ local function defineComponent(args)
 
     local generator = args.generator
 
-    function definition._create()
-        local component = generator()
+    function definition._create(props)
+        local component = generator(props)
 
         if typeof(component) ~= "table" then
             error(errorFormats.nonTableDefaultPropsReturn:format(args.name, typeof(component)))

--- a/src/defineComponent.spec.lua
+++ b/src/defineComponent.spec.lua
@@ -109,5 +109,43 @@ return function()
             component:setA(2)
             expect(component.a).to.equal(2)
         end)
+
+        it("should pass props argument to generator", function()
+            local class = defineComponent({
+                name = "Test",
+                generator = function(props)
+                    return {
+                        a = 1 + props.aAdd,
+                        b = 2 - props.bSubstract,
+                    }
+                end,
+            })
+
+            local component = class._create({
+                aAdd = 1,
+                bSubstract = 1,
+            })
+
+            expect(component.a).to.equal(2)
+            expect(component.b).to.equal(1)
+        end)
+
+        it("should accept any type as a props argument", function()
+            local class = defineComponent({
+                name = "Test",
+                generator = function(props)
+                    props = props or ""
+                    return {
+                        a = "foo"..props
+                    }
+                end,
+            })
+
+            local componentOne = class._create("bar")
+            local componentTwo = class._create()
+
+            expect(componentOne.a).to.equal("foobar")
+            expect(componentTwo.a).to.equal("foo")
+        end)
     end)
 end

--- a/src/defineComponent.spec.lua
+++ b/src/defineComponent.spec.lua
@@ -136,7 +136,7 @@ return function()
                 generator = function(props)
                     props = props or ""
                     return {
-                        a = "foo"..props
+                        a = "foo" .. props,
                     }
                 end,
             })

--- a/src/defineComponent.spec.lua
+++ b/src/defineComponent.spec.lua
@@ -111,9 +111,15 @@ return function()
         end)
 
         it("should pass props argument to generator", function()
+            local propsTable = {
+                aAdd = 1,
+                bSubstract = 1,
+            }
+            
             local class = defineComponent({
                 name = "Test",
                 generator = function(props)
+                    expect(props).to.equal(propsTable)
                     return {
                         a = 1 + props.aAdd,
                         b = 2 - props.bSubstract,
@@ -121,10 +127,7 @@ return function()
                 end,
             })
 
-            local component = class._create({
-                aAdd = 1,
-                bSubstract = 1,
-            })
+            local component = class._create(propsTable)
 
             expect(component.a).to.equal(2)
             expect(component.b).to.equal(1)


### PR DESCRIPTION
Allows passing of a props argument to component generators, allowing users to setup their components just before they are added to the core and events/plugin methods are fired.

The props argument can be anything and generators are expected to reason with it and do any type checking, rather than the component class. I'm wondering if we should instead force it to be either a table or nil.