### PR TITLE
Passes props through componentAdded plugin lifecycle

### DIFF
--- a/src/Core.lua
+++ b/src/Core.lua
@@ -334,7 +334,7 @@ function Core:addComponent(entityId, componentIdentifier, props)
             componentInstance = componentClass._create(props)
             componentInstances[entityId] = componentInstance
 
-            self:__callPluginMethod("componentAdded", entityId, componentInstance)
+            self:__callPluginMethod("componentAdded", entityId, componentInstance, props)
 
             local signal = self._componentAddedSignals[componentIdentifier]
             self._signalRaisers[signal](entityId, componentInstance)

--- a/src/Core.lua
+++ b/src/Core.lua
@@ -21,7 +21,7 @@
     - coreInit(Core): Called when the Core initializes.
     - componentRegistered(Core, componentClass): Called when a component class
       is registered in the core.
-    - componentAdded(Core, entityId, componentInstance): Called when a component
+    - componentAdded(Core, entityId, componentInstance, props): Called when a component
       instance is added to an entity. Called before the addition signal for that
       component has been fired.
     - componentRemoving(Core, entityId, componentInstance): Called when a

--- a/src/Core.spec/plugins.spec.lua
+++ b/src/Core.spec/plugins.spec.lua
@@ -114,25 +114,31 @@ return function()
             local callCount = 0
             local calledEntity = nil
             local calledComponentInstance = nil
+            local calledComponentProps = nil
 
             local plugin = {
-                componentAdded = function(self, core, entityId, componentInstance)
+                componentAdded = function(self, core, entityId, componentInstance, componentProps)
                     expect(componentInstance.className).to.equal("TestComponent")
 
                     callCount = callCount + 1
                     calledEntity = entityId
                     calledComponentInstance = componentInstance
+                    calledComponentProps = componentProps
                 end,
             }
 
             local core = Core.new({ plugin })
             core:registerComponent(ComponentClass)
             local entity = core:createEntity()
-            local _, componentInstance = core:addComponent(entity, ComponentClass)
+            local props = {
+                foo = "bar",
+            }
+            local _, componentInstance = core:addComponent(entity, ComponentClass, props)
 
             expect(callCount).to.equal(1)
             expect(entity).to.equal(calledEntity)
             expect(componentInstance).to.equal(calledComponentInstance)
+            expect(props).to.equal(calledComponentProps)
         end)
 
         it("should be called before events are fired in addComponent", function()


### PR DESCRIPTION
Previously, if props were used to add a component to an entity using `Core:addComponent`, the props would not be passed onto the `componentAdded` plugin lifecycle method.