### PR TITLE
Add Core:setStateComponent

### DIFF
--- a/src/Core.lua
+++ b/src/Core.lua
@@ -121,6 +121,8 @@ function Core.new(plugins)
         _plugins = plugins or {},
     }, Core)
 
+    self.None = {}
+
     self:__callPluginMethod("coreInit")
 
     return self
@@ -420,7 +422,11 @@ function Core:setStateComponent(entityId, componentIdentifier, newState)
         if componentInstance ~= nil then
 
             for attribute, value in pairs(newState) do
-                componentInstance[attribute] = value
+                if value == self.None then
+                    componentInstance[attribute] = nil
+                else
+                    componentInstance[attribute] = value
+                end
             end
 
             self:__callPluginMethod("componentStateSet", entityId, componentInstance)

--- a/src/Core.lua
+++ b/src/Core.lua
@@ -121,6 +121,9 @@ function Core.new(plugins)
         _plugins = plugins or {},
     }, Core)
 
+    -- A symbol that can be used in conjuction with Core:setStateComponent method
+    -- which will tell the Core to delete a field of a component if used as part of
+    -- the new given state.
     self.None = {}
 
     self:__callPluginMethod("coreInit")

--- a/src/Core.spec/getComponentStateSetSignal.spec.lua
+++ b/src/Core.spec/getComponentStateSetSignal.spec.lua
@@ -1,0 +1,71 @@
+local Core = require(script.Parent.Parent.Core)
+local defineComponent = require(script.Parent.Parent.defineComponent)
+
+return function()
+    local ComponentClass = defineComponent({
+        name = "TestComponent",
+        generator = function()
+            return {}
+        end
+    })
+
+    it("should get a signal", function()
+        local core = Core.new()
+        core:registerComponent(ComponentClass)
+
+        expect(core:getComponentStateSetSignal(ComponentClass)).to.be.ok()
+    end)
+
+    it("should always get the same signal", function()
+        local core = Core.new()
+        core:registerComponent(ComponentClass)
+
+        local signalA = core:getComponentStateSetSignal(ComponentClass)
+        local signalB = core:getComponentStateSetSignal(ComponentClass)
+        expect(signalA).to.equal(signalB)
+    end)
+
+    it("should fire when the component is added to an entity", function()
+        local core = Core.new()
+        core:registerComponent(ComponentClass)
+
+        local callCount = 0
+        local signal = core:getComponentStateSetSignal(ComponentClass)
+        signal:connect(function(entityId, componentInstance)
+            callCount = callCount + 1
+        end)
+
+        local entity = core:createEntity()
+		core:addComponent(entity, ComponentClass)
+		core:setStateComponent(entity, ComponentClass, {})
+
+        expect(callCount).to.equal(1)
+    end)
+
+    it("should be fired with the entity ID and the component instance", function()
+        local core = Core.new()
+        core:registerComponent(ComponentClass)
+
+        local entityId = core:createEntity()
+        local addedEntityId, addedComponentInstance = nil, nil
+
+        local signal = core:getComponentStateSetSignal(ComponentClass)
+        signal:connect(function(signalEntityId, signalComponentInstance)
+            addedEntityId = signalEntityId
+            addedComponentInstance = signalComponentInstance
+        end)
+
+		core:addComponent(entityId, ComponentClass)
+		local _, componentInstance = core:setStateComponent(entityId, ComponentClass, {})
+        expect(entityId).to.equal(addedEntityId)
+        expect(componentInstance).to.equal(addedComponentInstance)
+    end)
+
+    it("should throw if the component has not been registered", function()
+        local core = Core.new()
+
+        expect(function()
+            core:getComponentStateSetSignal(ComponentClass)
+        end).to.throw()
+    end)
+end

--- a/src/Core.spec/setComponentState.spec.lua
+++ b/src/Core.spec/setComponentState.spec.lua
@@ -1,0 +1,69 @@
+local Core = require(script.Parent.Parent.Core)
+local defineComponent = require(script.Parent.Parent.defineComponent)
+
+return function()
+    local ComponentClass = defineComponent({
+        name = "TestComponent",
+        generator = function()
+            return {
+                x = 0,
+                y = 0,
+            }
+        end
+    })
+
+    it("should set all the fields provided", function()
+        local core = Core.new()
+        core:registerComponent(ComponentClass)
+
+        local entity = core:createEntity()
+        core:addComponent(entity, ComponentClass)
+        core:setStateComponent(entity, ComponentClass, { x = 10, y = 20 })
+    end)
+
+    it("should return the added component", function()
+        local core = Core.new()
+        core:registerComponent(ComponentClass)
+
+        local entity = core:createEntity()
+        core:addComponent(entity, ComponentClass)
+        local success, component = core:setStateComponent(entity, ComponentClass, { x = 10, y = 20 })
+
+        expect(success).to.equal(true)
+        expect(component.x).to.equal(10)
+        expect(component.y).to.equal(20)
+    end)
+
+    it("should set only the fields provided", function()
+        local core = Core.new()
+        core:registerComponent(ComponentClass)
+
+        local entity = core:createEntity()
+        core:addComponent(entity, ComponentClass)
+        local success, component = core:setStateComponent(entity, ComponentClass, { x = 10 })
+
+        expect(success).to.equal(true)
+        expect(component.x).to.equal(10)
+        expect(component.y).to.equal(0)
+    end)
+
+    it("should throw if the component has not been registered", function()
+        local core = Core.new()
+        local entity = core:createEntity()
+
+        expect(function()
+            core:setStateComponent(entity, ComponentClass, { x = 0 })
+        end).to.throw()
+    end)
+
+    it("should throw if the component has not been added to the entity", function()
+        local core = Core.new()
+        core:registerComponent(ComponentClass)
+        local entity = core:createEntity()
+
+        expect(function()
+            core:setStateComponent(entity, ComponentClass, { x = 0 })
+        end).to.throw()
+    end)
+
+end

--- a/src/Core.spec/setStateComponent.spec.lua
+++ b/src/Core.spec/setStateComponent.spec.lua
@@ -47,6 +47,19 @@ return function()
         expect(component.y).to.equal(0)
     end)
 
+    it("should remove fields when given Core.None", function()
+        local core = Core.new()
+        core:registerComponent(ComponentClass)
+
+        local entity = core:createEntity()
+        core:addComponent(entity, ComponentClass)
+        local success, component = core:setStateComponent(entity, ComponentClass, { x = 10, y = core.None })
+
+        expect(success).to.equal(true)
+        expect(component.x).to.equal(10)
+        expect(component.y).to.equal(nil)
+    end)
+
     it("should throw if the component has not been registered", function()
         local core = Core.new()
         local entity = core:createEntity()


### PR DESCRIPTION
Adds the following members to Core to support a `setStateComponent` method

- Core:setStateComponent(entityId, componentId, newState)
    - Used to set the component's state of an entity
> Given an entity ID, a component identifier, and a dictionary of fields and values, overwrites the state of an existing component of the entity. Returns a boolean that is true if the component's state was changed. Throws if the identified component class has not been added to the entity or if the identified component class isn't registered in the Core.

- Core:getComponentStateSetSignal(componentId)
    - Fires when setStateComponent is called on an entity
> Gets a signal that fires whenever a component's state is set. The signal will be fired with the entity ID and the component that was set. Throws if the identified component class isn't registered in the Core.

- Core.None
    - When used with a new state of setStateComponent, will delete the value from the component's state.
> A symbol that can be used in conjunction with Core:setStateComponent method which will tell the Core to delete a field of a component if used as part of the new given state.