### PR TITLE
Add ComponentCleaner built-in plugin

### DIFF
--- a/src/BuiltInPlugins/ComponentCleaner.lua
+++ b/src/BuiltInPlugins/ComponentCleaner.lua
@@ -1,0 +1,20 @@
+--!strict
+
+local createCleaner = require(script.Parent.Parent.createCleaner)
+
+--[[
+	Plugin
+]]
+
+local componentCleaner = {}
+
+function componentCleaner:componentAdded(core, entityId, componentInstance)
+	componentInstance._cleaner = createCleaner()
+end
+
+function componentCleaner:componentRemoving(core, entityId, componentInstance)
+	componentInstance._cleaner:clean()
+	componentInstance._cleaner = nil
+end
+
+return componentCleaner

--- a/src/BuiltInPlugins/init.lua
+++ b/src/BuiltInPlugins/init.lua
@@ -1,4 +1,5 @@
 return {
     CollectionService = require(script.CollectionService),
     ComponentChangedEvent = require(script.ComponentChangedEvent),
+    ComponentCleaner = require(script.ComponentCleaner),
 }


### PR DESCRIPTION
Add a built-in plugin which adds a cleaner to each component instance. This allows Roblox instances/connections to be linked with components safely without resulting in memory leakage.