### PR TITLE
Update ComponentCleaner to assign the cleaner to .maid instead of _cleaner

### DIFF
--- a/src/BuiltInPlugins/ComponentCleaner.lua
+++ b/src/BuiltInPlugins/ComponentCleaner.lua
@@ -9,12 +9,12 @@ local createCleaner = require(script.Parent.Parent.createCleaner)
 local componentCleaner = {}
 
 function componentCleaner:componentAdded(core, entityId, componentInstance)
-	componentInstance._cleaner = createCleaner()
+	componentInstance.maid = createCleaner()
 end
 
 function componentCleaner:componentRemoving(core, entityId, componentInstance)
-	componentInstance._cleaner:clean()
-	componentInstance._cleaner = nil
+	componentInstance.maid:clean()
+	componentInstance.maid = nil
 end
 
 return componentCleaner


### PR DESCRIPTION
Updated ComponentCleaner to assign the cleaner to .maid instead of _cleaner to make it consistent with RECS's assigning of .maid to systems.